### PR TITLE
Dev/frontend

### DIFF
--- a/src/AST/Type.zig
+++ b/src/AST/Type.zig
@@ -753,19 +753,16 @@ pub fn sizeof(ty: Type, comp: *const Compilation) ?u64 {
         .DecayedIncompleteArray,
         .DecayedVariableLenArray,
         .DecayedUnspecifiedVariableLenArray,
+        .DecayedTypeofType,
+        .DecayedTypeofExpr,
         => comp.target.ptrBitWidth() >> 3,
 
         .Array => ty.data.array.elem.sizeof(comp).? * ty.data.array.len,
         .Struct, .Union => if (ty.data.record.isIncomplete()) null else ty.data.record.size,
         .Enum => if (ty.data.@"enum".isIncomplete()) null else ty.data.@"enum".tagType.sizeof(comp),
 
-        .TypeofType,
-        .DecayedTypeofType,
-        => ty.data.subType.sizeof(comp),
-
-        .TypeofExpr,
-        .DecayedTypeofExpr,
-        => ty.data.expr.ty.sizeof(comp),
+        .TypeofType => ty.data.subType.sizeof(comp),
+        .TypeofExpr => ty.data.expr.ty.sizeof(comp),
 
         .Attributed => ty.data.attributed.base.sizeof(comp),
     };

--- a/src/AST/Type.zig
+++ b/src/AST/Type.zig
@@ -571,6 +571,7 @@ pub fn integerPromotion(ty: Type, comp: *Compilation) Type {
 
             .TypeofType => return ty.data.subType.integerPromotion(comp),
             .TypeofExpr => return ty.data.expr.ty.integerPromotion(comp),
+            .Attributed => return ty.data.attributed.base.integerPromotion(comp),
 
             else => unreachable, // not an integer type
         },

--- a/src/Basic/LangOpts.zig
+++ b/src/Basic/LangOpts.zig
@@ -70,6 +70,8 @@ const Standard = enum {
 };
 
 standard: Standard = .default,
+/// -fshort-enums option, makes enums only take up as much space as they need to hold all the values.
+shortEnums: bool = false,
 
 pub fn setStandard(self: *LangOpts, name: []const u8) error{InvalidStandard}!void {
     self.standard = Standard.NameMap.get(name) orelse return error.InvalidStandard;

--- a/src/Basic/TokenType.zig
+++ b/src/Basic/TokenType.zig
@@ -174,6 +174,8 @@ pub const TokenType = enum(u8) {
     // GCC keywords
     KeywordGccConst1,
     KeywordGccConst2,
+    KeywordGccInline1,
+    KeywordGccInline2,
     KeywordGccVolatile1,
     KeywordGccVolatile2,
     KeywordGccRestrict1,
@@ -443,6 +445,8 @@ pub const TokenType = enum(u8) {
 
             .KeywordGccConst1 => "__const",
             .KeywordGccConst2 => "__const__",
+            .KeywordGccInline1 => "__inline",
+            .KeywordGccInline2 => "__inline__",
             .KeywordGccVolatile1 => "__volatile",
             .KeywordGccVolatile2 => "__volatile__",
             .KeywordGccRestrict1 => "__restrict",

--- a/src/Lexer/Token.zig
+++ b/src/Lexer/Token.zig
@@ -15,8 +15,8 @@ pub const Token = struct {
     /// belong to the implementation namespace, so we always convert them
     /// to keywords.
     /// TODO: add `.keyword_asm` here as GNU extension once that is supported.
-    pub fn getTokenId(comp: *const Compilation, str: []const u8, default: TokenType) TokenType {
-        const kw = AllKeywords.get(str) orelse return default; 
+    pub fn getTokenId(comp: *const Compilation, str: []const u8) TokenType {
+        const kw = AllKeywords.get(str) orelse return .Identifier;
         const standard = comp.langOpts.standard;
         return switch (kw) {
             .KeywordInline => if (standard.isGNU() or standard.atLeast(.c99)) kw else .Identifier,

--- a/src/Lexer/Token.zig
+++ b/src/Lexer/Token.zig
@@ -115,6 +115,8 @@ pub const Token = struct {
         // gcc keywords
         .{ "__const", .KeywordGccConst1 },
         .{ "__const__", .KeywordGccConst2 },
+        .{ "__inline", .KeywordGccInline1 },
+        .{ "__inline__", .KeywordGccInline2 },
         .{ "__volatile", .KeywordGccVolatile1 },
         .{ "__volatile__", .KeywordGccVolatile2 },
         .{ "__restrict", .KeywordGccRestrict1 },

--- a/src/Parser/Parser.zig
+++ b/src/Parser/Parser.zig
@@ -4648,6 +4648,8 @@ fn parseCallExpr(p: *Parser, lhs: Result) Error!Result {
             var arg = try p.assignExpr();
             try arg.expect(p);
             try arg.lvalConversion(p);
+            if (arg.ty.hasIncompleteSize() and !arg.ty.is(.Void))
+                return error.ParsingFailed;
 
             if (argCount < params.len) {
                 const paramType = params[argCount].ty;

--- a/src/Parser/Parser.zig
+++ b/src/Parser/Parser.zig
@@ -4232,7 +4232,7 @@ fn parseUnaryExpr(p: *Parser) Error!Result {
                 try p.errToken(.indirection_ptr, index);
             }
 
-            if (operand.ty.hasIncompleteSize())
+            if (operand.ty.hasIncompleteSize() and !operand.ty.is(.Void))
                 try p.errStr(.deref_incomplete_ty_ptr, asteriskLoc, try p.typeStr(operand.ty));
 
             operand.ty.qual = .{};

--- a/src/Parser/Parser.zig
+++ b/src/Parser/Parser.zig
@@ -2668,6 +2668,10 @@ fn convertInitList(p: *Parser, il: InitList, initType: Type) Error!NodeIndex {
     } else if (initType.is(.VariableLenArray)) {
         return error.ParsingFailed; // vla invalid, reported earlier
     } else if (initType.isArray()) {
+        // array element type invalid, reported earlier
+        if (initType.getElemType().hasIncompleteSize())
+            return error.ParsingFailed;
+
         if (il.node != .none)
             return il.node;
 

--- a/src/Parser/Parser.zig
+++ b/src/Parser/Parser.zig
@@ -4176,6 +4176,10 @@ fn parseUnaryExpr(p: *Parser) Error!Result {
     const index = p.index;
     switch (p.tokenIds[index]) {
         .Ampersand => {
+            if (p.inMacro) {
+                try p.err(.invalid_preproc_operator);
+                return error.ParsingFailed;
+            }
             p.index += 1;
             var operand = try p.parseCastExpr();
             try operand.expect(p);

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,6 +58,8 @@ const usage =
     \\  -E                      Only run the preprocessor
     \\  -fcolor-diagnostics     Enable colors in diagnostics
     \\  -fno-color-diagnostics  Disable colors in diagnostics
+    \\  -fshort-enums           Use the narrowest possible integer type for enums.
+    \\  -fno-short-enums        Use "int" as the tag type for enums.
     \\  -I <dir>                Add directory to include search path
     \\  -isystem                Add directory to system include search path
     \\  -o <file>               Write output to <file>
@@ -140,6 +142,10 @@ fn handleArgs(comp: *Compilation, args: [][]const u8) !void {
                 comp.diag.color = true;
             } else if (std.mem.eql(u8, arg, "-fno-color-diagnostics")) {
                 comp.diag.color = false;
+            } else if (std.mem.eql(u8, arg, "-fshort-enums")) {
+                comp.langOpts.shortEnums = true;
+            } else if (std.mem.eql(u8, arg, "-fno-short-enums")) {
+                comp.langOpts.shortEnums = false;
             } else if (std.mem.startsWith(u8, arg, "-I")) {
                 var path = arg["-I".len..];
                 if (path.len == 0) {

--- a/test/cases/assignment.c
+++ b/test/cases/assignment.c
@@ -61,6 +61,12 @@ void foo(void) {
     foo = 0;
 }
 
+void bar(void) {
+    int *a;
+    void *b;
+    a = b;
+    b = a;
+}
 
 #define EXPECTED_ERRORS "assignment.c:2:7: error: expression is not assignable" \
     "assignment.c:4:7: error: expression is not assignable" \

--- a/test/cases/attributes.c
+++ b/test/cases/attributes.c
@@ -76,6 +76,11 @@ void diagnostics(void) {
     x(0);
 }
 
+void math(void) {
+    int __attribute__((aligned(4))) x = 0;
+    (void) (x / 2);
+}
+
 #define EXPECTED_ERRORS "attributes.c:8:26: warning: Attribute 'noreturn' ignored in variable context" \
     "attributes.c:9:26: warning: unknown attribute 'does_not_exist' ignored" \
     "attributes.c:27:20: warning: Attribute 'deprecated' ignored in label context" \

--- a/test/cases/binary-expressions.c
+++ b/test/cases/binary-expressions.c
@@ -26,9 +26,10 @@ void foo(void) {
     (void)(1 ? (volatile int*)2 : (const void*)3);
     (void)(1 ? (const int *)1 : 0);
     (void)(1 ? 0 : (const int *)1);
-    // struct Foo { int a; } b, c;
-    // (void)(1 ? b : c);
-    // (void)(1 ? b : 1);
+    struct Foo { int a; } b;
+    const struct Foo c;
+    (void)(1 ? b : c);
+    (void)(1 ? b : 1);
     ?:;
     (void)(1 * (int)sizeof(int));
     int *ptr;
@@ -49,17 +50,18 @@ int baz = 0xFFFFFFFFFF + 1u;
 #define EXPECTED_ERRORS "binary-expressions.c:3:7: error: invalid operands to binary expression ('long' and 'float')" \
     "binary-expressions.c:6:13: error: invalid operands to binary expression ('char' and 'int *')" \
     "binary-expressions.c:8:9: error: invalid operands to binary expression ('void (*)(void)' and 'void')" \
-    "binary-expressions.c:10:15: warning: comparison of distinct pointer types ('float *' and 'int *')" \
-    "binary-expressions.c:11:7: warning: comparison between pointer and integer ('int' and 'int *')" \
+    "binary-expressions.c:10:15: warning: comparison of distinct pointer types ('float *' and 'int *') [-Wcompare-distinct-pointer-types]" \
+    "binary-expressions.c:11:7: warning: comparison between pointer and integer ('int' and 'int *') [-Wpointer-integer-compare]" \
     "binary-expressions.c:12:9: error: invalid operands to binary expression ('double' and 'int *')" \
     "binary-expressions.c:13:24: error: invalid operands to binary expression ('_Complex double' and 'int')" \
     "binary-expressions.c:15:13: error: invalid operands to binary expression ('int *' and 'int *')" \
     "binary-expressions.c:18:7: error: invalid operands to binary expression ('int' and 'int *')" \
     "binary-expressions.c:19:13: error: incompatible pointer types ('int *' and 'float *')" \
-    "binary-expressions.c:21:17: warning: implicit integer to pointer conversion from 'int' to 'int *'" \
-    "binary-expressions.c:22:11: warning: implicit integer to pointer conversion from 'int' to 'int *'" \
-    "binary-expressions.c:24:24: warning: pointer type mismatch ('int *' and 'float *')" \
-    "binary-expressions.c:32:5: error: expected statement" \
-    "binary-expressions.c:37:5: error: expected expression" \
-    "binary-expressions.c:38:13: error: expected expression" \
+    "binary-expressions.c:21:17: warning: implicit integer to pointer conversion from 'int' to 'int *' [-Wint-conversion]" \
+    "binary-expressions.c:22:11: warning: implicit integer to pointer conversion from 'int' to 'int *' [-Wint-conversion]" \
+    "binary-expressions.c:24:24: warning: pointer type mismatch ('int *' and 'float *') [-Wpointer-type-mismatch]" \
+    "binary-expressions.c:32:18: error: invalid operands to binary expression ('struct Foo' and 'int')" \
+    "binary-expressions.c:33:5: error: expected statement" \
+    "binary-expressions.c:38:5: error: expected expression" \
+    "binary-expressions.c:39:13: error: expected expression" \
 

--- a/test/cases/call.c
+++ b/test/cases/call.c
@@ -29,6 +29,11 @@ void foo(void) {
     var(1, 1.f, (char)1, a);
 }
 
+enum E;
+void bar(enum E e) {
+    baz(e);
+}
+
 #define EXPECTED_ERRORS "call.c:16:7: error: passing 'void' to parameter of incompatible type" \
     "call.c:5:21: note: passing argument to parameter here" \
     "call.c:19:7: warning: implicit pointer to integer conversion from 'int *' to 'int'" \
@@ -40,5 +45,7 @@ void foo(void) {
     "call.c:25:8: error: passing 'float' to parameter of incompatible type" \
     "call.c:8:20: note: passing argument to parameter here" \
     "call.c:28:7: error: passing 'int' to parameter of incompatible type" \
-    "call.c:9:25: note: passing argument to parameter here"
+    "call.c:9:25: note: passing argument to parameter here" \
+    "call.c:33:17: error: parameter has incomplete type 'enum E'" \
+    "call.c:34:5: warning: implicit declaration of function 'baz' is invalid in C99" \
 

--- a/test/cases/containers.c
+++ b/test/cases/containers.c
@@ -64,6 +64,16 @@ union SomeUnion {
 };
 typedef union SomeUnion SomeUnion;
 
+typedef struct forward_struct forward_struct;
+struct forward_struct {
+    forward_struct *a;
+};
+
+typedef enum forward_enum forward_enum;
+enum forward_enum {
+    forward_enum_a = sizeof(forward_enum *),
+};
+
 #define EXPECTED_ERRORS "containers.c:15:8: error: use of 'Foo' with tag type that does not match previous definition" \
     "containers.c:9:6: note: previous definition is here" \
     "containers.c:15:12: error: variable has incomplete type 'struct Foo'" \

--- a/test/cases/deref-void.c
+++ b/test/cases/deref-void.c
@@ -1,0 +1,6 @@
+void foo(void) {
+    void *p = 0;
+    (void)*p;
+    p = &*p;
+}
+

--- a/test/cases/initializers.c
+++ b/test/cases/initializers.c
@@ -34,6 +34,7 @@ void foo(void) {
     struct S s = {};
     enum E e1 = 1, e2 = 2 + e1;
     union U u = {.x = 1};
+    void v[1] = {1};
 } 
 
 #define TESTS_SKIPPED 2
@@ -66,3 +67,4 @@ void foo(void) {
     "initializers.c:34:14: error: variable has incomplete type 'struct S'" \
     "initializers.c:35:12: error: variable has incomplete type 'enum E'" \
     "initializers.c:36:13: error: variable has incomplete type 'union U'" \
+    "initializers.c:37:11: error: array has incomplete element type 'void'" \

--- a/test/cases/preprocessor-binary-operators.c
+++ b/test/cases/preprocessor-binary-operators.c
@@ -59,6 +59,9 @@ error "failed"
 error "failed"
 #endif
 
+#if 1 + &x
+#endif
+
 #define EXPECTED_ERRORS "preprocessor-binary-operators.c:1:5: error: invalid token at start of a preprocessor expression" \
 	"preprocessor-binary-operators.c:5:5: error: invalid token at start of a preprocessor expression" \
 	"preprocessor-binary-operators.c:9:7: error: token is not a valid binary operator in a preprocessor subexpression" \
@@ -71,3 +74,4 @@ error "failed"
 	"preprocessor-binary-operators.c:50:5: error: string literal in preprocessor expression" \
 	"preprocessor-binary-operators.c:53:9: error: token is not a valid binary operator in a preprocessor subexpression" \
 	"preprocessor-binary-operators.c:53:9: error: invalid token at start of a preprocessor expression" \
+	"preprocessor-binary-operators.c:62:9: error: token is not a valid binary operator in a preprocessor subexpression" \

--- a/test/cases/statements.c
+++ b/test/cases/statements.c
@@ -15,6 +15,8 @@ void foo(void) {
     enum FOO {BAR, BAZ} y = BAR;
     if (y) return;
     if (!BAZ) return;
+    int a, b;
+    for (a=1,b=1;;);
 }
 
 

--- a/test/cases/typeof.c
+++ b/test/cases/typeof.c
@@ -107,6 +107,14 @@ void test_my_other_func(void) {
     f = my_other_func(42);
 }
 
+void sizeof_decayed(int x) {
+    char vla[x];
+    typeof(vla) vla2;
+    -vla2;
+}
+
+
+
 #define EXPECTED_ERRORS "typeof.c:24:9: warning: incompatible pointer types assigning to 'int *' from incompatible type 'float *'" \
     "typeof.c:28:7: error: expression is not assignable" \
     "typeof.c:30:7: error: expression is not assignable" \
@@ -121,3 +129,4 @@ void test_my_other_func(void) {
     "typeof.c:74:13: error: expression is not assignable" \
     "typeof.c:77:13: error: expression is not assignable" \
     "typeof.c:98:29: warning: initializing 'int *' from incompatible type 'const int *' discards qualifiers" \
+    "typeof.c:113:5: error: invalid argument type 'char *' to unary expression" \


### PR DESCRIPTION
- [Parser]: add derefencing pointers to void
- [Parser]: prevet array init if array element type is incomplete type
- [Parser]: treat decayed typeof-types as pointers in Type.sizeof()
- [Parser]: don't allow address-of in preprocessor expressions
- [Parser]: Prevent call expression with incomplete-size argument
- [Parser]: add `-fshort-enums`  option  to correctly handle enumerations
-  add __inline and __inline__ GCC keywords
- Fix unused expression check for comma operator
- Check record types in conditional opeartor branches
- Allow assignment from other to void *
- Fix superfluous error on uses of forward declared record/enum tags