### PR TITLE
[Parser]: implement __auto_type

### DIFF
--- a/doc/support.md
+++ b/doc/support.md
@@ -222,6 +222,7 @@ void bar(float, char) {
 - [x] `__real, __real__`
 - [x] `__typeof__, __typeof`
 - [x] `__attribute, __attribute__`
+- [x] `__auto_type`
 
 - **Binary Literal**
   - [x] `0b11`

--- a/src/AST/DeclSpec.zig
+++ b/src/AST/DeclSpec.zig
@@ -21,6 +21,7 @@ threadLocal: ?TokenIndex = null,
 constexpr: ?TokenIndex = null,
 @"inline": ?TokenIndex = null,
 noreturn: ?TokenIndex = null,
+autoType: ?TokenIndex = null,
 type: Type,
 
 pub fn validateParam(d: DeclSpec, p: *Parser, ty: *Type) Error!void {
@@ -34,6 +35,10 @@ pub fn validateParam(d: DeclSpec, p: *Parser, ty: *Type) Error!void {
     if (d.@"inline") |tokenIndex| try p.errStr(.func_spec_non_func, tokenIndex, "inline");
     if (d.noreturn) |tokenIndex| try p.errStr(.func_spec_non_func, tokenIndex, "_Noreturn");
     if (d.constexpr) |tokenIndex| try p.errToken(.invalid_storage_on_param, tokenIndex);
+    if (d.autoType) |tokenIndex| {
+        try p.errStr(.auto_type_not_allowed, tokenIndex, "function prototype");
+        ty.* = Type.Invalid;
+    }
 }
 
 pub fn validateFnDef(d: DeclSpec, p: *Parser) Error!AstTag {

--- a/src/Basic/Compilation.zig
+++ b/src/Basic/Compilation.zig
@@ -395,7 +395,7 @@ fn generateBuiltinTypes(comp: *Compilation) !void {
         .xcore => Type.UChar,
         .ve, .msp430 => Type.UInt,
         .arm, .armeb, .thumb, .thumbeb => if (os != .windows and os != .netbsd and os != .openbsd) Type.UInt else Type.Int,
-        .aarch64, .aarch64_be, .aarch64_32 => if (!os.isDarwin() and os != .netbsd) Type.UInt else Type.Int,
+        .aarch64, .aarch64_be => if (!os.isDarwin() and os != .netbsd) Type.UInt else Type.Int,
         .x86_64, .x86 => if (os == .windows) Type.UShort else Type.Int,
         else => Type.Int,
     };

--- a/src/Basic/Diagnostics.zig
+++ b/src/Basic/Diagnostics.zig
@@ -158,6 +158,7 @@ pub const Options = packed struct {
     @"pre-c2x-compat": Kind = .default,
     @"pointer-bool-conversion": Kind = .default,
     @"string-conversion": Kind = .default,
+    @"gnu-auto-type": Kind = .default,
 };
 
 list: std.ArrayListUnmanaged(Message) = .{},

--- a/src/Basic/DiagnosticsMessages.zig
+++ b/src/Basic/DiagnosticsMessages.zig
@@ -2051,3 +2051,44 @@ pub const bitint_suffix = struct {
     pub const kind = .warning;
     pub const suppress_version = .c2x;
 };
+pub const auto_type_extension = struct {
+    pub const msg = "'__auto_type' is a GNU extension";
+    pub const opt = "gnu-auto-type";
+    pub const kind = .off;
+    pub const pedantic = true;
+};
+pub const auto_type_not_allowed = struct {
+    pub const msg = "'__auto_type' not allowed in {s}";
+    pub const kind = .@"error";
+    pub const extra = .str;
+};
+pub const auto_type_requires_initializer = struct {
+    pub const msg = "declaration of variable '{s}' with deduced type requires an initializer";
+    pub const kind = .@"error";
+    pub const extra = .str;
+};
+pub const auto_type_requires_single_declarator = struct {
+    pub const msg = "'__auto_type' may only be used with a single declarator";
+    pub const kind = .@"error";
+};
+pub const auto_type_requires_plain_declarator = struct {
+    pub const msg = "'__auto_type' requires a plain identifier as declarator";
+    pub const kind = .@"error";
+};
+pub const invalid_cast_to_auto_type = struct {
+    pub const msg = "Invalid cast to '__auto_type'";
+    pub const kind = .@"error";
+};
+pub const auto_type_from_bitfield = struct {
+    pub const msg = "cannot use bit-field as '__auto_type' initializer";
+    pub const kind = .@"error";
+};
+pub const array_of_auto_type = struct {
+    pub const msg = "'{s}' declared as array of '__auto_type'";
+    pub const kind = .@"error";
+    pub const extra = .str;
+};
+pub const auto_type_with_init_list = struct {
+    pub const msg = "cannot use '__auto_type' with initializer list";
+    pub const kind = .@"error";
+};

--- a/src/Basic/Target.zig
+++ b/src/Basic/Target.zig
@@ -122,7 +122,6 @@ pub fn int64Type(target: std.Target) Type {
 pub fn getCharSignedness(target: std.Target) std.builtin.Signedness {
     switch (target.cpu.arch) {
         .aarch64,
-        .aarch64_32,
         .aarch64_be,
         .arm,
         .armeb,
@@ -146,7 +145,7 @@ pub fn getCharSignedness(target: std.Target) std.builtin.Signedness {
 pub fn defaultFunctionAlignment(target: std.Target) u8 {
     return switch (target.cpu.arch) {
         .arm, .armeb => 4,
-        .aarch64, .aarch64_32, .aarch64_be => 4,
+        .aarch64, .aarch64_be => 4,
         .sparc, .sparcel, .sparc64 => 4,
         .riscv64 => 2,
         else => 1,

--- a/src/Basic/TokenType.zig
+++ b/src/Basic/TokenType.zig
@@ -135,6 +135,7 @@ pub const TokenType = enum(u8) {
     One,
 
     KeywordAuto,
+    KeywordAutoType,
     KeywordBreak,
     KeywordCase,
     KeywordChar,
@@ -318,6 +319,7 @@ pub const TokenType = enum(u8) {
             .MacroFunction,
             .MacroPrettyFunc,
             .KeywordAuto,
+            .KeywordAutoType,
             .KeywordBreak,
             .KeywordCase,
             .KeywordChar,
@@ -567,6 +569,7 @@ pub const TokenType = enum(u8) {
             .AngleBracketAngleBracketRightEqual => ">>=",
 
             .KeywordAuto => "auto",
+            .KeywordAutoType => "__auto_type",
             .KeywordBreak => "break",
             .KeywordCase => "case",
             .KeywordChar => "char",

--- a/src/Lexer/Attribute.zig
+++ b/src/Lexer/Attribute.zig
@@ -1253,7 +1253,7 @@ pub fn applyFunctionAttributes(p: *Parser, ty: Type, attrBufferStart: usize) !Ty
                 else => try p.errStr(.callconv_not_supported, tok, p.tokenIds[tok].getTokenText().?),
             },
             .vectorcall => switch (p.comp.target.cpu.arch) {
-                .x86, .aarch64, .aarch64_be, .aarch64_32 => try p.attrApplicationBuffer.append(p.gpa, attr),
+                .x86, .aarch64, .aarch64_be => try p.attrApplicationBuffer.append(p.gpa, attr),
                 else => try p.errStr(.callconv_not_supported, tok, p.tokenIds[tok].getTokenText().?),
             },
         },

--- a/src/Lexer/Lexer.zig
+++ b/src/Lexer/Lexer.zig
@@ -914,7 +914,7 @@ test "operators" {
 
 test "keywords" {
     try expectTokens(
-        \\auto break case char const continue default do 
+        \\auto __auto_type break case char const continue default do 
         \\double else enum extern float for goto if int 
         \\long register return short signed sizeof static 
         \\struct switch typedef union unsigned void volatile 
@@ -924,6 +924,7 @@ test "keywords" {
         \\
     , &.{
         .KeywordAuto,
+        .KeywordAutoType,
         .KeywordBreak,
         .KeywordCase,
         .KeywordChar,

--- a/src/Lexer/Token.zig
+++ b/src/Lexer/Token.zig
@@ -159,6 +159,7 @@ pub const Token = struct {
         .{ "__PRETTY_FUNCTION__", .MacroPrettyFunc },
 
         // gcc keywords
+        .{ "__auto_type", .KeywordAutoType },
         .{ "__const", .KeywordGccConst1 },
         .{ "__const__", .KeywordGccConst2 },
         .{ "__inline", .KeywordGccInline1 },

--- a/src/Parser/Result.zig
+++ b/src/Parser/Result.zig
@@ -929,7 +929,10 @@ pub fn castType(res: *Result, p: *Parser, to: Type, tok: TokenIndex) !void {
             res.value.intCast(res.ty, to, p.comp);
         }
     } else {
-        try p.errStr(.invalid_cast_type, tok, try p.typeStr(to));
+        if (to.is(.AutoType))
+            try p.errToken(.invalid_cast_to_auto_type, tok)
+        else
+            try p.errStr(.invalid_cast_type, tok, try p.typeStr(to));
         return error.ParsingFailed;
     }
 

--- a/test/cases/__auto_type.c
+++ b/test/cases/__auto_type.c
@@ -1,0 +1,81 @@
+//zcc-args -Wno-gnu-alignof-expression
+#include "test-helpers.h"
+__auto_type foo(void);
+__auto_type foo1(void) {}
+
+void bar(__auto_type);
+void bar1(__auto_type x) {}
+
+typedef __auto_type my_auto_type;
+int __auto_type a = 5;
+
+struct S {
+    unsigned bitfield: 5;
+};
+struct BadStruct {
+    __auto_type y;
+};
+union BadUnion {
+    __auto_type x;
+};
+
+int myfunc(int x) { return x; }
+
+void baz(void) {
+
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic warning "-Wgnu-auto-type"
+#   pragma GCC diagnostic ignored "-Wsizeof-array-argument"
+    __auto_type decayed_arr = (double[]){1., 2., 3., 4., 5.};
+    _Static_assert(sizeof(decayed_arr) == sizeof(double *), "");
+#   pragma GCC diagnostic pop
+
+    __auto_type b = 5U;
+    EXPECT_TYPE(b, unsigned);
+    int c = (__auto_type)5;
+
+    __auto_type d;
+
+    __auto_type e = 1, f = 2;
+
+    struct S s = {};
+    __auto_type g = s.bitfield;
+
+    const int const_int = 5;
+    __auto_type h = const_int;
+    h = 100;
+
+    const __auto_type i = 0;
+    i += 1;
+
+    __auto_type func_ptr = myfunc;
+    EXPECT_TYPE(func_ptr, __typeof__(&myfunc));
+    EXPECT_TYPE(func_ptr, int (*)(int));
+
+    __auto_type my_struct = (struct S){.bitfield = 10 };
+    EXPECT_TYPE(my_struct, struct S);
+
+    __auto_type auto_array[2] = {1, 2};
+
+    __auto_type init_list = {1,2};
+
+    __attribute__((aligned(128))) __auto_type aligned_var = 0ULL;
+    _Static_assert(_Alignof(aligned_var) == 128, "");
+}
+
+#define EXPECTED_ERRORS "__auto_type.c:3:1: error: '__auto_type' not allowed in function return type" \
+    "__auto_type.c:4:1: error: '__auto_type' not allowed in function return type" \
+    "__auto_type.c:6:10: error: '__auto_type' not allowed in function prototype" \
+    "__auto_type.c:7:11: error: '__auto_type' not allowed in function prototype" \
+    "__auto_type.c:9:9: error: '__auto_type' not allowed in typedef" \
+    "__auto_type.c:10:5: error: cannot combine with previous 'int' specifier" \
+    "__auto_type.c:16:17: error: '__auto_type' not allowed in struct member" \
+    "__auto_type.c:19:17: error: '__auto_type' not allowed in union member" \
+    "__auto_type.c:29:5: warning: '__auto_type' is a GNU extension [-Wgnu-auto-type]" \
+    "__auto_type.c:35:13: error: Invalid cast to '__auto_type'" \
+    "__auto_type.c:37:17: error: declaration of variable 'd' with deduced type requires an initializer" \
+    "__auto_type.c:39:5: error: '__auto_type' may only be used with a single declarator" \
+    "__auto_type.c:42:21: error: cannot use bit-field as '__auto_type' initializer" \
+    "__auto_type.c:49:7: error: expression is not assignable" \
+    "__auto_type.c:58:17: error: 'auto_array' declared as array of '__auto_type'" \
+    "__auto_type.c:60:29: error: cannot use '__auto_type' with initializer list" \


### PR DESCRIPTION
This implements GCC-style `__auto_type` as a type specifier. Clang implements it as C++ `auto` which is more powerful in that it allows multiple declarators and non-simple declarators. C23 auto is based on the GCC variant.